### PR TITLE
Uses new finer-grained track state provided by daily-js. Provides a b…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1047,15 +1047,25 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@daily-co/daily-js": {
-      "version": "0.9.995",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.9.995.tgz",
-      "integrity": "sha512-FbW6xguhovLuVddWE7S0470Vl3k+u44JmIy9vIHscd5M+LNekaJegTwf7egoMGK0rTl1l1e5NpuUTGF5N4dZRw==",
+      "version": "0.9.997",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.9.997.tgz",
+      "integrity": "sha512-41Y9ugKeA/4N0ZtVkv70LugQee1yJExJGmGQipfUghjVewXWI2ojoKmwcqJDyBQJi5hEKPqqUfpkU7rh2fLfSA==",
       "requires": {
-        "@babel/runtime": "^7.8.3",
+        "@babel/runtime": "^7.12.5",
         "bowser": "^2.8.1",
         "events": "^3.1.0",
         "fast-equals": "^1.6.3",
         "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@daily-co/daily-js": "^0.9.995",
+    "@daily-co/daily-js": "^0.9.997",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/components/Call/Call.js
+++ b/src/components/Call/Call.js
@@ -140,11 +140,11 @@ export default function Call() {
       const tile = (
         <Tile
           key={id}
-          videoTrack={callItem.videoTrack}
-          audioTrack={callItem.audioTrack}
+          videoTrackState={callItem.videoTrackState}
+          audioTrackState={callItem.audioTrackState}
           isLocalPerson={isLocal(id)}
           isLarge={isLarge}
-          isLoading={callItem.isLoading}
+          disableCornerMessage={isScreenShare(id)}
           onClick={
             isLocal(id)
               ? null

--- a/src/components/Tile/Tile.css
+++ b/src/components/Tile/Tile.css
@@ -33,13 +33,25 @@
   border-radius: 4px;
 }
 
-.tile .loading {
+.tile .overlay {
   position: absolute;
   color: #ffffff;
   top: 50%;
   left: 50%;
   margin: 0;
   transform: translate(-50%, -50%);
+  font-size: 14px;
+  line-height: 17px;
+}
+
+.tile .corner {
+  position: absolute;
+  color: #ffffff;
+  background-color: #000000;
+  padding: 10px;
+  margin: 0;
+  bottom: 0;
+  left: 0;
   font-size: 14px;
   line-height: 17px;
 }

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -1,49 +1,117 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import './Tile.css';
+
+function getTrackUnavailableMessage(kind, trackState) {
+  if (!trackState) return;
+  switch (trackState.state) {
+    case 'blocked':
+      if (trackState.blocked.byPermissions) {
+        return `${kind} permission denied`;
+      } else if (trackState.blocked.byDeviceMissing) {
+        return `${kind} device missing`;
+      }
+    case 'off':
+      if (trackState.off.byUser) {
+        return `${kind} off`;
+      } else if (trackState.off.byBandwidth) {
+        return `${kind} muted to save bandwidth`;
+      }
+    case 'sendable':
+      return `${kind} not subscribed`;
+    case 'loading':
+      return `${kind} loading...`;
+    case 'interrupted':
+      return `${kind} interrupted`;
+    case 'playable':
+      return null;
+  }
+}
 
 /**
  * Props
- * - videoTrack: MediaStreamTrack?
- * - audioTrack: MediaStreamTrack?
+ * - videoTrackState: DailyTrackState?
+ * - audioTrackState: DailyTrackState?
  * - isLocalPerson: boolean
  * - isLarge: boolean
- * - isLoading: boolean
+ * - disableCornerMessage: boolean
  * - onClick: Function
  */
 export default function Tile(props) {
   const videoEl = useRef(null);
   const audioEl = useRef(null);
 
+  const videoTrack = useMemo(() => {
+    return props.videoTrackState && props.videoTrackState.state === 'playable'
+      ? props.videoTrackState.track
+      : null;
+  }, [props.videoTrackState]);
+
+  const audioTrack = useMemo(() => {
+    return props.audioTrackState && props.audioTrackState.state === 'playable'
+      ? props.audioTrackState.track
+      : null;
+  }, [props.audioTrackState]);
+
+  const videoUnavailableMessage = useMemo(() => {
+    return getTrackUnavailableMessage('video', props.videoTrackState);
+  }, [props.videoTrackState]);
+
+  const audioUnavailableMessage = useMemo(() => {
+    return getTrackUnavailableMessage('audio', props.audioTrackState);
+  }, [props.audioTrackState]);
+
   /**
    * When video track changes, update video srcObject
    */
   useEffect(() => {
     videoEl.current &&
-      (videoEl.current.srcObject = new MediaStream([props.videoTrack]));
-  }, [props.videoTrack]);
+      (videoEl.current.srcObject = new MediaStream([videoTrack]));
+  }, [videoTrack]);
 
   /**
    * When audio track changes, update audio srcObject
    */
   useEffect(() => {
     audioEl.current &&
-      (audioEl.current.srcObject = new MediaStream([props.audioTrack]));
-  }, [props.audioTrack]);
-
-  function getLoadingComponent() {
-    return props.isLoading && <p className="loading">Loading...</p>;
-  }
+      (audioEl.current.srcObject = new MediaStream([audioTrack]));
+  }, [audioTrack]);
 
   function getVideoComponent() {
-    return (
-      props.videoTrack && <video autoPlay muted playsInline ref={videoEl} />
-    );
+    return videoTrack && <video autoPlay muted playsInline ref={videoEl} />;
   }
 
   function getAudioComponent() {
     return (
       !props.isLocalPerson &&
-      props.audioTrack && <audio autoPlay playsInline ref={audioEl} />
+      audioTrack && <audio autoPlay playsInline ref={audioEl} />
+    );
+  }
+
+  function getOverlayComponent() {
+    // Show overlay when video is unavailable. Audio may be unavailable too.
+    return (
+      videoUnavailableMessage && (
+        <p className="overlay">
+          {videoUnavailableMessage}
+          {audioUnavailableMessage && (
+            <>
+              <br />
+              {audioUnavailableMessage}
+            </>
+          )}
+        </p>
+      )
+    );
+  }
+
+  function getCornerMessageComponent() {
+    // Show corner message when only audio is unavailable.
+    return (
+      !props.disableCornerMessage &&
+      audioUnavailableMessage &&
+      !videoUnavailableMessage && (
+        <p className="corner">{audioUnavailableMessage}</p>
+      )
     );
   }
 
@@ -57,9 +125,10 @@ export default function Tile(props) {
   return (
     <div className={getClassNames()} onClick={props.onClick}>
       <div className="background" />
-      {getLoadingComponent()}
+      {getOverlayComponent()}
       {getVideoComponent()}
       {getAudioComponent()}
+      {getCornerMessageComponent()}
     </div>
   );
 }

--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -12,7 +12,7 @@ function getTrackUnavailableMessage(kind, trackState) {
       }
     case 'off':
       if (trackState.off.byUser) {
-        return `${kind} off`;
+        return `${kind} muted`;
       } else if (trackState.off.byBandwidth) {
         return `${kind} muted to save bandwidth`;
       }


### PR DESCRIPTION
…it more detail than you might in a totally realistic implementation (e.g. separating video and audio loading states), for the dual purpose of illustration as well as validating the daily-js behavior.

Equivalent of https://github.com/daily-co/rn-daily-js-playground/pull/47

Note: this PR is marked "do not merge" because not all of the required daily-js changes have been published yet (and some haven't even been merged yet into daily-js' main) **and** we need to decide when we feel the new track state API is "baked" enough, but I wanted to give folks a chance to review now.

![Screen Shot 2020-12-23 at 11 23 23 AM](https://user-images.githubusercontent.com/782801/103042412-7ef65700-4547-11eb-804b-4d5504619e4d.png)
![Screen Shot 2020-12-23 at 11 23 18 AM](https://user-images.githubusercontent.com/782801/103042413-7ef65700-4547-11eb-98cf-b6252091bb44.png)
![Screen Shot 2020-12-23 at 11 23 11 AM](https://user-images.githubusercontent.com/782801/103042414-7ef65700-4547-11eb-9cf4-7dff2bf3dbef.png)
![Screen Shot 2020-12-23 at 11 27 52 AM](https://user-images.githubusercontent.com/782801/103042405-7dc52a00-4547-11eb-81ce-3f4a577fe44e.png)
![Screen Shot 2020-12-23 at 11 27 15 AM](https://user-images.githubusercontent.com/782801/103042406-7dc52a00-4547-11eb-8366-1ebe0ac3153b.png)
![Screen Shot 2020-12-23 at 11 25 42 AM](https://user-images.githubusercontent.com/782801/103042407-7e5dc080-4547-11eb-9fe1-5f3dddeb794e.png)
![Screen Shot 2020-12-23 at 11 25 29 AM](https://user-images.githubusercontent.com/782801/103042408-7e5dc080-4547-11eb-89f0-f6b039979ce7.png)
![Screen Shot 2020-12-23 at 11 24 32 AM](https://user-images.githubusercontent.com/782801/103042409-7e5dc080-4547-11eb-91b1-74b9224cbe19.png)
![Screen Shot 2020-12-23 at 11 23 57 AM](https://user-images.githubusercontent.com/782801/103042410-7e5dc080-4547-11eb-9029-f24616ff9d2e.png)
![Screen Shot 2020-12-23 at 11 23 33 AM](https://user-images.githubusercontent.com/782801/103042411-7e5dc080-4547-11eb-870c-3a5111818e6a.png)






