### PR TITLE
Defensively future-proof the track unavailable message against new re…

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -10,12 +10,14 @@ function getTrackUnavailableMessage(kind, trackState) {
       } else if (trackState.blocked.byDeviceMissing) {
         return `${kind} device missing`;
       }
+      return `${kind} blocked`;
     case 'off':
       if (trackState.off.byUser) {
         return `${kind} muted`;
       } else if (trackState.off.byBandwidth) {
         return `${kind} muted to save bandwidth`;
       }
+      return `${kind} off`;
     case 'sendable':
       return `${kind} not subscribed`;
     case 'loading':


### PR DESCRIPTION
…asons a track might be "off" of "blocked"—it should never fall through to other cases.