### PR TITLE
Use `persistentTrack` rather than `track` for audio playback.

### DIFF
--- a/src/components/Tile/Tile.js
+++ b/src/components/Tile/Tile.js
@@ -43,15 +43,20 @@ export default function Tile(props) {
   const audioEl = useRef(null);
 
   const videoTrack = useMemo(() => {
-    return props.videoTrackState && props.videoTrackState.state === 'playable'
-      ? props.videoTrackState.track
-      : null;
+    // For video let's use the `track` field, which is only present when video
+    // is in the "playable" state.
+    // (Using `persistentTrack` could result in a still frame being shown when
+    // remote video is muted).
+    return props.videoTrackState?.track;
   }, [props.videoTrackState]);
 
   const audioTrack = useMemo(() => {
-    return props.audioTrackState && props.audioTrackState.state === 'playable'
-      ? props.audioTrackState.track
-      : null;
+    // For audio let's use the `persistentTrack` field, which is present whether
+    // or not audio is in the "playable" state.
+    // (Using `track` would result in a bug where, if remote audio were unmuted
+    // while this call was is in a Safari background tab, audio wouldn't resume
+    // playing).
+    return props.audioTrackState?.persistentTrack;
   }, [props.audioTrackState]);
 
   const videoUnavailableMessage = useMemo(() => {
@@ -67,7 +72,7 @@ export default function Tile(props) {
    */
   useEffect(() => {
     videoEl.current &&
-      (videoEl.current.srcObject = new MediaStream([videoTrack]));
+      (videoEl.current.srcObject = videoTrack && new MediaStream([videoTrack]));
   }, [videoTrack]);
 
   /**
@@ -75,7 +80,7 @@ export default function Tile(props) {
    */
   useEffect(() => {
     audioEl.current &&
-      (audioEl.current.srcObject = new MediaStream([audioTrack]));
+      (audioEl.current.srcObject = audioTrack && new MediaStream([audioTrack]));
   }, [audioTrack]);
 
   function getVideoComponent() {


### PR DESCRIPTION
Wanted to open this up for a quick discussion.

Using `persistentTrack` rather than `track` for audio is something we've been doing in our Prebuilt for quite a while to avoid the remote-unmute-while-in-Safari-background-tab bug, and @jptaylor and I have discussed cementing this practice as a formal recommendation in our:
* demos
* public documentation
* TS declaration

@Regaddi, @lizadaily, and @jessmitch42—since you've worked on the newer Prebuilt migration onto Web Audio (though it looks like we're not using it for Safari?), I wanted to get your take on whether you believe we can/should still put `persistentTrack` forward as recommended best practice.